### PR TITLE
chore: add Pixelmatters reference to license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Rui Martins
+Copyright (c) 2021 Pixelmatters
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Replace the @rmartins90 reference on the license file and replace it with Pixelmatters.